### PR TITLE
Improvements to bfCL stability have been made to enhance mining experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This is an experimental port of [TWLbf](https://github.com/Jimmy-Z/TWLbf/) to Op
 
 ## Compile
 ### Windows
-Note: If you really want to use Virtual Studio 2017, you're going to probably have to change the Makefile a bit and compile [mbedtls](https://github.com/ARMmbed/mbedtls/) from source.
+Note: If you really want to use Visual Studio 2017, you're going to probably have to change the Makefile a bit and compile [mbedtls](https://github.com/ARMmbed/mbedtls/) from source.
 #### Requirements for compiling with MSYS2
 * **A 64-bit computer**
 * [MSYS2](http://www.msys2.org/) (the x86_64 executable; **read its instructions on installing and setting up**)

--- a/bfcl.c
+++ b/bfcl.c
@@ -4,8 +4,11 @@
 #include "utils.h"
 #include "ocl.h"
 #include "ocl_brute.h"
+#include "ocl_util.h"
 
 int ocl_test();
+
+int seedminer_mode = 0;
 
 static inline cl_ushort u16be(const unsigned char *in){
 	cl_ushort out;
@@ -24,6 +27,89 @@ int main(int argc, const char *argv[]) {
 	} else if (argc == 2 && !strcmp(argv[1], "info")) {
 		cl_uint num_platforms;
 		ocl_info(&num_platforms, 1);
+	// Extremely condensed arguemnt parsing incoming!
+	} else if ((argc == 5 && !strcmp(argv[1], "msky")) || ((argc == 6 && !strcmp(argv[1], "msky")) && (!strcmp(argv[5], "sws") || !strcmp(argv[5], "rws"))) || ((argc == 7 && !strcmp(argv[1], "msky")) && ((!strcmp(argv[5], "sws") && !strcmp(argv[6], "sm")) || (!strcmp(argv[5], "rws") && !strcmp(argv[6], "sm"))))) {
+		uint32_t msky[4], ver[4], msky_offset;
+		hex2bytes((unsigned char*)msky, 16, argv[2], 1);
+		hex2bytes((unsigned char*)ver, 16, argv[3], 1);
+		hex2bytes((unsigned char*)&msky_offset, 4, argv[4], 1);
+		if (argc == 5 && !strcmp(argv[1], "msky")) {
+			group_bits = 28;
+			/*Uncomment the following (and delete this current line) when a new Seedminer Python script is realeased:
+			char response;
+			printf("\nWARNING: Deprecated parameters are being used (most liekly due to using an outdated Seedminer Python script!\nIf problems occur and you are using Seedminer, download an updated Python script.\nWould you like to continue? Enter Y or N: \n");
+			scanf("%c", &response);
+			while (1 == 1) {
+				if (response == 'Y' || response == 'y')
+					break;
+				else if (response == 'N' || response == 'n')
+					exit(0);
+				else {
+					printf("Invalid option chosen!\nWould you like to continue with the mining? Enter Y or N: \n");
+					scanf(" %c", &response);
+				}
+			}*/
+		} else if ((argc == 6 || argc == 7) && !strcmp(argv[5], "sws")) {
+			group_bits = 28;
+		} else if ((argc == 6 || argc == 7) && !strcmp(argv[5], "rws")) {
+			group_bits = 20;
+		}
+		if (argc == 7 && !strcmp(argv[6], "sm"))
+			seedminer_mode = 1;
+		ret = ocl_brute_msky(msky, ver, msky_offset);
+	// More extremely condensed arguemnt parsing incoming!
+	} else if ((argc == 6 && !strcmp(argv[1], "lfcs")) || ((argc == 7 && !strcmp(argv[1], "lfcs")) && (!strcmp(argv[6], "sws") || !strcmp(argv[6], "rws"))) || ((argc == 8 && !strcmp(argv[1], "msky")) && ((!strcmp(argv[6], "sws") && !strcmp(argv[7], "sm")) || (!strcmp(argv[6], "rws") && !strcmp(argv[7], "sm"))))) {
+		uint32_t lfcs, ver[2], lfcs_offset;
+		uint16_t newflag;
+		hex2bytes((unsigned char*)&lfcs, 4, argv[2], 1);
+		hex2bytes((unsigned char*)&newflag, 2, argv[3], 1);
+		hex2bytes((unsigned char*)ver, 8, argv[4], 1);
+		hex2bytes((unsigned char*)&lfcs_offset, 4, argv[5], 1);
+		if (argc == 6 && !strcmp(argv[1], "lfcs")) {
+			group_bits = 28;
+			/*Uncomment the following (and delete this current line) when a new Seedminer Python script is realeased:
+			char response;
+			printf("\nWARNING: Deprecated parameters are being used (most liekly due to using an outdated Seedminer Python script!\nIf problems occur and you are using Seedminer, download an updated Python script.\nWould you like to continue? Enter Y or N: \n");
+			scanf("%c", &response);
+			while (1 == 1) {
+				if (response == 'Y' || response == 'y')
+					break;
+				else if (response == 'N' || response == 'n')
+					exit(0);
+				else {
+					printf("Invalid option chosen!\nWould you like to continue with the mining? Enter Y or N: \n");
+					scanf(" %c", &response);
+				}
+			}*/
+		} else if ((argc == 7 || argc == 8) && !strcmp(argv[6], "sws")) {
+			group_bits = 28;
+		} else if ((argc == 7 || argc == 8) && !strcmp(argv[6], "rws")) {
+			group_bits = 20;
+		}
+		if (argc == 8 && !strcmp(argv[7], "sm"))
+			seedminer_mode = 1;
+		group_bits = 28;
+		ret = ocl_brute_lfcs(lfcs, newflag, ver, lfcs_offset);
+	} else if (argc == 7) {
+		unsigned char console_id[8], emmc_cid[16], offset[2], src[16], ver[16];
+		hex2bytes(console_id, 8, argv[2], 1);
+		hex2bytes(emmc_cid, 16, argv[3], 1);
+		hex2bytes(offset, 2, argv[4], 1);
+		hex2bytes(src, 16, argv[5], 1);
+		hex2bytes(ver, 16, argv[6], 1);
+
+		if (!strcmp(argv[1], "console_id")) {
+			ret = ocl_brute_console_id(console_id, emmc_cid, u16be(offset), src, ver, 0, 0, 0, NORMAL);
+		} else if (!strcmp(argv[1], "console_id_bcd")) {
+			ret = ocl_brute_console_id(console_id, emmc_cid, u16be(offset), src, ver, 0, 0, 0, BCD);
+		} else if (!strcmp(argv[1], "console_id_3ds")) {
+			ret = ocl_brute_console_id(console_id, emmc_cid, u16be(offset), src, ver, 0, 0, 0, CTR);
+		} else if (!strcmp(argv[1], "emmc_cid")) {
+			ret = ocl_brute_emmc_cid(console_id, emmc_cid, u16be(offset), src, ver);
+		} else {
+			puts(invalid_parameters);
+			ret = -1;
+		}
 	} else if (argc == 9) {
 		unsigned char console_id[8],
 			offset0[2], src0[16], ver0[16],
@@ -49,78 +135,9 @@ int main(int argc, const char *argv[]) {
 			puts(invalid_parameters);
 			ret = -1;
 		}
-	} else if (argc == 7 && strcmp(argv[1], "lfcs")) {
-		unsigned char console_id[8], emmc_cid[16], offset[2], src[16], ver[16];
-		hex2bytes(console_id, 8, argv[2], 1);
-		hex2bytes(emmc_cid, 16, argv[3], 1);
-		hex2bytes(offset, 2, argv[4], 1);
-		hex2bytes(src, 16, argv[5], 1);
-		hex2bytes(ver, 16, argv[6], 1);
-
-		if (!strcmp(argv[1], "console_id")) {
-			ret = ocl_brute_console_id(console_id, emmc_cid, u16be(offset), src, ver, 0, 0, 0, NORMAL);
-		} else if (!strcmp(argv[1], "console_id_bcd")) {
-			ret = ocl_brute_console_id(console_id, emmc_cid, u16be(offset), src, ver, 0, 0, 0, BCD);
-		} else if (!strcmp(argv[1], "console_id_3ds")) {
-			ret = ocl_brute_console_id(console_id, emmc_cid, u16be(offset), src, ver, 0, 0, 0, CTR);
-		} else if (!strcmp(argv[1], "emmc_cid")) {
-			ret = ocl_brute_emmc_cid(console_id, emmc_cid, u16be(offset), src, ver);
-		} else {
-			puts(invalid_parameters);
-			ret = -1;
-		}
-	} else if(argc == 6 && !strcmp(argv[1], "msky") && !strcmp(argv[5], "sws")){ // "sws" is standard work size
-		uint32_t msky[4], ver[4], msky_offset;
-		hex2bytes((unsigned char*)msky, 16, argv[2], 1);
-		hex2bytes((unsigned char*)ver, 16, argv[3], 1);
-		hex2bytes((unsigned char*)&msky_offset, 4, argv[4], 1);
-		group_bits = 28;
-		ret = ocl_brute_msky(msky, ver, msky_offset);
-	} else if(argc == 6 && !strcmp(argv[1], "msky") && !strcmp(argv[5], "rws")){ // "rws" is reduced work size
-		uint32_t msky[4], ver[4], msky_offset;
-		hex2bytes((unsigned char*)msky, 16, argv[2], 1);
-		hex2bytes((unsigned char*)ver, 16, argv[3], 1);
-		hex2bytes((unsigned char*)&msky_offset, 4, argv[4], 1);
-		group_bits = 20;
-		ret = ocl_brute_msky(msky, ver, msky_offset);
-	} else if(argc == 5 && !strcmp(argv[1], "msky")){ // In the event a work size argument isn't provided, the standard work size shall be used.
-		uint32_t msky[4], ver[4], msky_offset;
-		hex2bytes((unsigned char*)msky, 16, argv[2], 1);
-		hex2bytes((unsigned char*)ver, 16, argv[3], 1);
-		hex2bytes((unsigned char*)&msky_offset, 4, argv[4], 1);
-		group_bits = 28;
-		ret = ocl_brute_msky(msky, ver, msky_offset);
-	} else if(argc == 7 && !strcmp(argv[1], "lfcs") && !strcmp(argv[6], "sws")){ // "sws" is standard work size
-		uint32_t lfcs, ver[2], lfcs_offset;
-		uint16_t newflag;
-		hex2bytes((unsigned char*)&lfcs, 4, argv[2], 1);
-		hex2bytes((unsigned char*)&newflag, 2, argv[3], 1);
-		hex2bytes((unsigned char*)ver, 8, argv[4], 1);
-		hex2bytes((unsigned char*)&lfcs_offset, 4, argv[5], 1);
-		group_bits = 28;
-		ret = ocl_brute_lfcs(lfcs, newflag, ver, lfcs_offset);
-	} else if(argc == 7 && !strcmp(argv[1], "lfcs") && !strcmp(argv[6], "rws")){ // "rws" is reduced work size
-		uint32_t lfcs, ver[2], lfcs_offset;
-		uint16_t newflag;
-		hex2bytes((unsigned char*)&lfcs, 4, argv[2], 1);
-		hex2bytes((unsigned char*)&newflag, 2, argv[3], 1);
-		hex2bytes((unsigned char*)ver, 8, argv[4], 1);
-		hex2bytes((unsigned char*)&lfcs_offset, 4, argv[5], 1);
-		group_bits = 20;
-		ret = ocl_brute_lfcs(lfcs, newflag, ver, lfcs_offset);
-	} else if(argc == 6 && !strcmp(argv[1], "lfcs")){ // In the event a work size argument isn't provided, the standard work size shall be used.
-		uint32_t lfcs, ver[2], lfcs_offset;
-		uint16_t newflag;
-		hex2bytes((unsigned char*)&lfcs, 4, argv[2], 1);
-		hex2bytes((unsigned char*)&newflag, 2, argv[3], 1);
-		hex2bytes((unsigned char*)ver, 8, argv[4], 1);
-		hex2bytes((unsigned char*)&lfcs_offset, 4, argv[5], 1);
-		group_bits = 28;
-		ret = ocl_brute_lfcs(lfcs, newflag, ver, lfcs_offset);
 	} else {
 		printf(invalid_parameters);
 		ret = -1;
 	}
 	return ret;
 }
-

--- a/bfcl.c
+++ b/bfcl.c
@@ -37,7 +37,7 @@ int main(int argc, const char *argv[]) {
 			group_bits = 28;
 			/*Uncomment the following (and delete this current line) when a new Seedminer Python script is realeased:
 			char response;
-			printf("\nWARNING: Deprecated parameters are being used (most likely due to using an outdated Seedminer Python script!\nIf problems occur and you are using Seedminer, download an updated Python script.\nWould you like to continue? Enter Y or N: \n");
+			printf("\nWARNING: Deprecated arguments are being used (most likely due to using an outdated Seedminer Python script!\nIf problems occur and you are using Seedminer, download an updated Python script.\nWould you like to continue? Enter Y or N: \n");
 			scanf("%c", &response);
 			while (1 == 1) {
 				if (response == 'Y' || response == 'y')
@@ -69,7 +69,7 @@ int main(int argc, const char *argv[]) {
 			group_bits = 28;
 			/*Uncomment the following (and delete this current line) when a new Seedminer Python script is realeased:
 			char response;
-			printf("\nWARNING: Deprecated parameters are being used (most likely due to using an outdated Seedminer Python script!\nIf problems occur and you are using Seedminer, download an updated Python script.\nWould you like to continue? Enter Y or N: \n");
+			printf("\nWARNING: Deprecated arguments are being used (most likely due to using an outdated Seedminer Python script!\nIf problems occur and you are using Seedminer, download an updated Python script.\nWould you like to continue? Enter Y or N: \n");
 			scanf("%c", &response);
 			while (1 == 1) {
 				if (response == 'Y' || response == 'y')

--- a/bfcl.c
+++ b/bfcl.c
@@ -37,7 +37,7 @@ int main(int argc, const char *argv[]) {
 			group_bits = 28;
 			/*Uncomment the following (and delete this current line) when a new Seedminer Python script is realeased:
 			char response;
-			printf("\nWARNING: Deprecated arguments are being used (most likely due to using an outdated Seedminer Python script!\nIf problems occur and you are using Seedminer, download an updated Python script.\nWould you like to continue? Enter Y or N: \n");
+			printf("\nWARNING: Deprecated parameters are being used (most likely due to using an outdated Seedminer Python script!\nIf problems occur and you are using Seedminer, download an updated Python script.\nWould you like to continue? Enter Y or N: \n");
 			scanf("%c", &response);
 			while (1 == 1) {
 				if (response == 'Y' || response == 'y')
@@ -69,7 +69,7 @@ int main(int argc, const char *argv[]) {
 			group_bits = 28;
 			/*Uncomment the following (and delete this current line) when a new Seedminer Python script is realeased:
 			char response;
-			printf("\nWARNING: Deprecated arguments are being used (most likely due to using an outdated Seedminer Python script!\nIf problems occur and you are using Seedminer, download an updated Python script.\nWould you like to continue? Enter Y or N: \n");
+			printf("\nWARNING: Deprecated parameters are being used (most likely due to using an outdated Seedminer Python script!\nIf problems occur and you are using Seedminer, download an updated Python script.\nWould you like to continue? Enter Y or N: \n");
 			scanf("%c", &response);
 			while (1 == 1) {
 				if (response == 'Y' || response == 'y')

--- a/bfcl.c
+++ b/bfcl.c
@@ -27,7 +27,7 @@ int main(int argc, const char *argv[]) {
 	} else if (argc == 2 && !strcmp(argv[1], "info")) {
 		cl_uint num_platforms;
 		ocl_info(&num_platforms, 1);
-	// Extremely condensed arguemnt parsing incoming!
+	// Extremely condensed argument parsing incoming!
 	} else if ((argc == 5 && !strcmp(argv[1], "msky")) || ((argc == 6 && !strcmp(argv[1], "msky")) && (!strcmp(argv[5], "sws") || !strcmp(argv[5], "rws"))) || ((argc == 7 && !strcmp(argv[1], "msky")) && ((!strcmp(argv[5], "sws") && !strcmp(argv[6], "sm")) || (!strcmp(argv[5], "rws") && !strcmp(argv[6], "sm"))))) {
 		uint32_t msky[4], ver[4], msky_offset;
 		hex2bytes((unsigned char*)msky, 16, argv[2], 1);
@@ -57,7 +57,7 @@ int main(int argc, const char *argv[]) {
 		if (argc == 7 && !strcmp(argv[6], "sm"))
 			seedminer_mode = 1;
 		ret = ocl_brute_msky(msky, ver, msky_offset);
-	// More extremely condensed arguemnt parsing incoming!
+	// More extremely condensed argument parsing incoming!
 	} else if ((argc == 6 && !strcmp(argv[1], "lfcs")) || ((argc == 7 && !strcmp(argv[1], "lfcs")) && (!strcmp(argv[6], "sws") || !strcmp(argv[6], "rws"))) || ((argc == 8 && !strcmp(argv[1], "msky")) && ((!strcmp(argv[6], "sws") && !strcmp(argv[7], "sm")) || (!strcmp(argv[6], "rws") && !strcmp(argv[7], "sm"))))) {
 		uint32_t lfcs, ver[2], lfcs_offset;
 		uint16_t newflag;

--- a/bfcl.c
+++ b/bfcl.c
@@ -37,7 +37,7 @@ int main(int argc, const char *argv[]) {
 			group_bits = 28;
 			/*Uncomment the following (and delete this current line) when a new Seedminer Python script is realeased:
 			char response;
-			printf("\nWARNING: Deprecated parameters are being used (most liekly due to using an outdated Seedminer Python script!\nIf problems occur and you are using Seedminer, download an updated Python script.\nWould you like to continue? Enter Y or N: \n");
+			printf("\nWARNING: Deprecated parameters are being used (most likely due to using an outdated Seedminer Python script!\nIf problems occur and you are using Seedminer, download an updated Python script.\nWould you like to continue? Enter Y or N: \n");
 			scanf("%c", &response);
 			while (1 == 1) {
 				if (response == 'Y' || response == 'y')
@@ -69,7 +69,7 @@ int main(int argc, const char *argv[]) {
 			group_bits = 28;
 			/*Uncomment the following (and delete this current line) when a new Seedminer Python script is realeased:
 			char response;
-			printf("\nWARNING: Deprecated parameters are being used (most liekly due to using an outdated Seedminer Python script!\nIf problems occur and you are using Seedminer, download an updated Python script.\nWould you like to continue? Enter Y or N: \n");
+			printf("\nWARNING: Deprecated parameters are being used (most likely due to using an outdated Seedminer Python script!\nIf problems occur and you are using Seedminer, download an updated Python script.\nWould you like to continue? Enter Y or N: \n");
 			scanf("%c", &response);
 			while (1 == 1) {
 				if (response == 'Y' || response == 'y')

--- a/ocl_brute.c
+++ b/ocl_brute.c
@@ -385,7 +385,7 @@ int ocl_brute_msky(const cl_uint *msky, const cl_uint *ver, cl_uint msky_offset)
 			if (out) {
 				get_hp_time(&t1); td = hp_time_diff(&t0, &t1);
 				cl_uint msky_ret[4] = { msky[0], msky[1], out, msky3 };
-				printf("got a hit: %s\n", hexdump(msky_ret, 16, 0));
+				printf("got a hit: %s at offset: %d\n", hexdump(msky_ret, 16, 0), msky3_offset);
 				u8 msed[0x140]={0};
 				memcpy(&msed[0x110], msky_ret, 16);
 				dump_to_file("movable.sed", msed, 0x140);
@@ -516,7 +516,7 @@ int ocl_brute_lfcs(cl_uint lfcs_template, cl_ushort newflag, const cl_uint *ver,
 			if (out) {
 				get_hp_time(&t1); td = hp_time_diff(&t0, &t1);
 				lfcs += out >> 16;
-				printf("got a hit: %s (rand: 0x%04x)\n", hexdump(&lfcs, 4, 0), out & 0xffff);
+				printf("got a hit: %s (rand: 0x%04x) at offset: %d\n", hexdump(&lfcs, 4, 0), out & 0xffff, lfcs_offset);
 				u8 part1[0x1000]={0};
 				memcpy(part1, &lfcs, 4);
 				memcpy(part1+4, &newflag, 2);

--- a/ocl_brute.c
+++ b/ocl_brute.c
@@ -32,6 +32,8 @@ static cl_ulong from_bcd(cl_ulong i) {
 	return o;
 }
 
+unsigned group_bits;
+
 int ocl_brute_console_id(const cl_uchar *console_id, const cl_uchar *emmc_cid,
 	cl_uint offset0, const cl_uchar *src0, const cl_uchar *ver0,
 	cl_uint offset1, const cl_uchar *src1, const cl_uchar *ver1,

--- a/ocl_brute.h
+++ b/ocl_brute.h
@@ -18,4 +18,4 @@ int ocl_brute_msky(const cl_uint *msky, const cl_uint *ver, cl_uint msky_offset)
 
 int ocl_brute_lfcs(cl_uint lfcs_template, cl_ushort newflag, const cl_uint *ver, cl_uint lfcs_offset);
 
-unsigned group_bits;
+extern unsigned group_bits;

--- a/ocl_util.c
+++ b/ocl_util.c
@@ -9,6 +9,7 @@
 #endif
 #include "ocl.h"
 #include "utils.h"
+#include "ocl_util.h"
 
 #define STATIC_ASSERT(c) static_assert(c, #c)
 STATIC_ASSERT(sizeof(char) == sizeof(cl_char));
@@ -47,7 +48,10 @@ const char * ocl_err_msg(cl_int error_code) {
 
 void ocl_assert(cl_int ret, const char * code, const char * file,
 	const char * function, unsigned line) {
-	if (ret != CL_SUCCESS) {
+	// Silence "Out of Resources" error if Seedminer is being used
+	if (ret == CL_OUT_OF_RESOURCES && seedminer_mode == 1)
+		exit(ret);
+	else if (ret != CL_SUCCESS) {
 		printf("%s: %s, function %s, line %u\n\t%s\nerror: %s\n",
 			__FUNCTION__, file, function, line, code, ocl_err_msg(ret));
 		exit(ret);

--- a/ocl_util.h
+++ b/ocl_util.h
@@ -1,0 +1,1 @@
+extern int seedminer_mode;


### PR DESCRIPTION
Things changed:
- Argument parsing for msky and lfcs mining have been moved into one if statement, each
- Argument parsing in general, have been improved
- LFCS mining is now guaranteed to work again
- Add a Seedminer mode argument of sorts that hides the OpenCL "Out of Resources" error
- Display final offset after msky and lfcs mining is completed
- Commented out code that alerts users that they may be using an outdated script if they don't use work size and/or seedminer arguments
- Probably some other things I'm forgetting to mention