### PR TITLE
Remove a function that won't be used

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -196,26 +196,3 @@ void intHandler() {
 	stop_bfcl = 1;
 	exit(0);
 }
-
-void deprecation_notice_and_input() {
-	char response[2];
-	// NO BUFFER OVERFLOWS CAN HAPPEN HERE!!! >:(
-	printf("\nWARNING: Deprecated parameters are being used (most likely due to using an outdated Seedminer Python script)!\nIf problems occur and you are using Seedminer, download an updated Python script.\nWould you like to continue? Enter Y or N: ");
-	fflush(stdout);
-	// As long as your response starts with a "y" or an "n", it'll be accepted and the rest will be truncated.
-	fgets(response, sizeof(response), stdin);
-	fflush(stdin);
-	while (1) {
-		real_sleep(1);
-		if (!strcmp(response, "Y") || !strcmp(response, "y")) {
-			break;
-		} else if (!strcmp(response, "N") || !strcmp(response, "n")) {
-			exit(0);
-		} else {
-			printf("\nInvalid choice chosen!\nWould you like to continue with the mining? Enter Y or N: ");
-			fflush(stdout);
-			fgets(response, sizeof(response), stdin);
-			fflush(stdin);
-		}
-	}
-}

--- a/utils.h
+++ b/utils.h
@@ -49,5 +49,3 @@ uint32_t reduced_work_size_mode;
 void real_sleep(int sleep_sec);
 
 void intHandler();
-
-void deprecation_notice_and_input();


### PR DESCRIPTION
A compilation error is generated on Linux since the return code of fgets() is ignored, but since the function I made doesn't need to be used; I just went ahead and removed it completely.