### PR TITLE
Fix AMD Score Boost on OSX for thunderbolt 3 connected devices

### DIFF
--- a/ocl_util.c
+++ b/ocl_util.c
@@ -193,7 +193,8 @@ void ocl_get_device(cl_platform_id *p_platform_id, cl_device_id *p_device_id) {
 				&& devices[j].c_avail == CL_TRUE){
 				cl_ulong cap = 1ull * devices[j].max_compute_units * devices[j].freq;
 				// unfortunately that metric is not comparable between different vendors
-				if (strstr((const char*)devices[j].vendor, "Advanced Micro Devices") != 0) {
+				if ((strstr((const char*)devices[j].vendor, "Advanced Micro Devices") != 0) ||
+				   (strstr((const char*)devices[j].vendor, "AMD") != 0)) {
 					cap *= 64;
 				} else if(strstr((const char*)devices[j].vendor, "NVIDIA") != 0) {
 					cap *= 128;


### PR DESCRIPTION
Sometimes AMD cards show a vendor name of "AMD" so I added it in so that the scores are comparable. This issue caused an Intel Iris GPU to be preferred over an AMD rx580.