### PR TITLE
OpenCL unroll for loops on sha256 computation

### DIFF
--- a/cl/sha256_16.cl
+++ b/cl/sha256_16.cl
@@ -88,6 +88,7 @@ void sha256_12(unsigned char *io)
 	W[15] = 0x60u;
 #endif
 
+#pragma unroll 16
 	for (i = 0; i < 16; i += 8)
 	{
 		P(A[0], A[1], A[2], A[3], A[4], A[5], A[6], A[7], W[i + 0], K[i + 0]);
@@ -100,6 +101,7 @@ void sha256_12(unsigned char *io)
 		P(A[1], A[2], A[3], A[4], A[5], A[6], A[7], A[0], W[i + 7], K[i + 7]);
 	}
 
+#pragma unroll 48
 	for (i = 16; i < 64; i += 8)
 	{
 		P(A[0], A[1], A[2], A[3], A[4], A[5], A[6], A[7], R(i + 0), K[i + 0]);


### PR DESCRIPTION
This allows Nvidia and Intel GPUs to generate code that runs alot faster on GPUs. 
GPUs are bad at conditionals this is why we see such drastic improvements with this change.
Performance on AMD seems to be slightly slower if not identical, the performance gains on nvidia make more than up for it tho.

AMDs OpenCL compiler probably already performs this optimization automatically, hence no significant difference. 

`NVIDIA RTX 2060 (~2.6x performance)
old average: 860 m/s
new average: 2270 m/s`

`Intel(R) UHD Graphics 630 (~1.2x performance)
old average: 53.57 m/s
new average: 63.56 m/s`